### PR TITLE
Release 2.0.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^8.1",
         "ext-json": "*",
-        "pdeans/http": "^2.0"
+        "pdeans/http": "^2.0.2"
     },
     "autoload": {
         "psr-4": {

--- a/readme.md
+++ b/readme.md
@@ -389,7 +389,7 @@ $response = $api->send();
 $response = $api->send(true);
 ```
 
-You may preview the current request body at any time before sending the request by using the `getRequestBody` method. Helpful for debugging requests.
+You may preview the current request body at any time before sending the request by using the `getRequestBody` method. This is helpful for debugging requests.
 
 ```php
 echo '<pre>', $api->getRequestBody(), '</pre>';

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -112,7 +112,7 @@ final class Auth
     /**
      * Set the list of valid HMAC types
      */
-    protected function setHmacList(): self
+    protected function setHmacList(): static
     {
         $this->hmacList = [
             'sha1',
@@ -125,7 +125,7 @@ final class Auth
     /**
      * Set the HMAC type.
      */
-    protected function setHmacType(string $hmacType): self
+    protected function setHmacType(string $hmacType): static
     {
         if (!$this->hmacList) {
             $this->setHmacList();

--- a/src/Builders/FilterBuilder.php
+++ b/src/Builders/FilterBuilder.php
@@ -68,7 +68,7 @@ class FilterBuilder implements BuilderInterface
     /**
      * Add a filter to the filter value list.
      */
-    public function addFilter(): self
+    public function addFilter(): static
     {
         $name = strtolower($this->name);
 

--- a/src/Builders/FunctionBuilder.php
+++ b/src/Builders/FunctionBuilder.php
@@ -85,7 +85,7 @@ class FunctionBuilder implements BuilderInterface
     /**
      * Set the number of records to return.
      */
-    public function count(int $count): self
+    public function count(int $count): static
     {
         $this->count = $count;
 
@@ -97,7 +97,7 @@ class FunctionBuilder implements BuilderInterface
      *
      * @throws \pdeans\Miva\Api\Exceptions\InvalidValueException
      */
-    public function filter(string $filterName, mixed $filterValue): self
+    public function filter(string $filterName, mixed $filterValue): static
     {
         if (trim($filterName) === '') {
             throw new InvalidValueException('Invalid value "' . $filterName . '" provided for filter name.');
@@ -111,7 +111,7 @@ class FunctionBuilder implements BuilderInterface
     /**
      * Add a list of filters to the filter list.
      */
-    public function filters(array $filters): self
+    public function filters(array $filters): static
     {
         foreach ($filters as $filterName => $filterValue) {
             $this->filter($filterName, $filterValue);
@@ -189,7 +189,7 @@ class FunctionBuilder implements BuilderInterface
     /**
      * Set the offset of the first record to return.
      */
-    public function offset(int $offset): self
+    public function offset(int $offset): static
     {
         $this->offset = $offset;
 
@@ -199,7 +199,7 @@ class FunctionBuilder implements BuilderInterface
     /**
      * Shorthand method to set the ondemandcolumns filter list.
      */
-    public function odc(array $columns): self
+    public function odc(array $columns): static
     {
         $this->ondemandcolumns($columns);
 
@@ -209,7 +209,7 @@ class FunctionBuilder implements BuilderInterface
     /**
      * Set the ondemandcolumns filter list
      */
-    public function ondemandcolumns(array $columns): self
+    public function ondemandcolumns(array $columns): static
     {
         $this->filter('ondemandcolumns', $columns);
 
@@ -219,7 +219,7 @@ class FunctionBuilder implements BuilderInterface
     /**
      * Set additional function input parameters.
      */
-    public function params(array $parameters): self
+    public function params(array $parameters): static
     {
         $this->parameterList = $parameters;
 
@@ -229,7 +229,7 @@ class FunctionBuilder implements BuilderInterface
     /**
      * Set the passphrase parameter.
      */
-    public function passphrase(string $passphrase): self
+    public function passphrase(string $passphrase): static
     {
         $this->passphrase = $passphrase;
 
@@ -241,7 +241,7 @@ class FunctionBuilder implements BuilderInterface
      *
      * @throws \pdeans\Miva\Api\Exceptions\InvalidValueException
      */
-    public function search(mixed ...$args): self
+    public function search(mixed ...$args): static
     {
         $argsCount = func_num_args();
 
@@ -273,7 +273,7 @@ class FunctionBuilder implements BuilderInterface
     /**
      * Add a show filter to the filter list.
      */
-    public function show(string $showValue): self
+    public function show(string $showValue): static
     {
         $this->filterList[] = (new FilterBuilder('show', $showValue, $this->name))->addFilter();
 
@@ -283,7 +283,7 @@ class FunctionBuilder implements BuilderInterface
     /**
      * Set the column to sort results.
      */
-    public function sort(string $sortColumn): self
+    public function sort(string $sortColumn): static
     {
         $this->sort = strtolower($sortColumn);
 
@@ -293,7 +293,7 @@ class FunctionBuilder implements BuilderInterface
     /**
      * Set the column to sort results in descending order.
      */
-    public function sortDesc(string $sortColumn): self
+    public function sortDesc(string $sortColumn): static
     {
         $this->sort = '-' . strtolower(ltrim($sortColumn, '-'));
 

--- a/src/Builders/RequestBuilder.php
+++ b/src/Builders/RequestBuilder.php
@@ -60,7 +60,7 @@ class RequestBuilder implements BuilderInterface
     /**
      * Add the current FunctionBuilder instance to the API request function list.
      */
-    public function addFunction(): self
+    public function addFunction(): static
     {
         $this->functionList[$this->function->name][] = $this->function;
 
@@ -129,7 +129,7 @@ class RequestBuilder implements BuilderInterface
     /**
      * Set the function property with a new function builder instance and add function name to function list.
      */
-    public function newFunction(string $name): self
+    public function newFunction(string $name): static
     {
         $this->function = new FunctionBuilder($name);
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -89,7 +89,7 @@ class Client
         $this->prevResponse = null;
         $this->request = null;
 
-        $this->createRequest();
+        $this->createRequestBuilder();
         $this->setUrl($this->options['url']);
 
         $this->headers = [];
@@ -138,7 +138,7 @@ class Client
     /**
      * Clear the current request builder instance.
      */
-    protected function clearRequest(): static
+    protected function clearRequestBuilder(): static
     {
         $this->requestBuilder = null;
 
@@ -148,7 +148,7 @@ class Client
     /**
      * Create a new request builder instance.
      */
-    protected function createRequest(): static
+    protected function createRequestBuilder(): static
     {
         $this->requestBuilder = new RequestBuilder(
             (string) $this->options['store_code'],
@@ -247,10 +247,10 @@ class Client
      */
     protected function refreshRequestBuilder(): static
     {
-        if ($this->request instanceof Request) {
-            $this->clearRequest();
-            $this->createRequest();
+        $this->clearRequestBuilder();
+        $this->createRequestBuilder();
 
+        if ($this->request instanceof Request) {
             $this->request->setRequestBuilder($this->requestBuilder);
         }
 


### PR DESCRIPTION
- Fixed underlying request handler open file/stream issue
- Updated references of `self` to `static` for method return value hints
- Added new `public` method to `Client` class:
	- `getRequest`
- Renamed methods in `Client` class:
	- Renamed `clearRequest` to `clearRequestBuilder`
	- Renamed `createRequest` to `createRequestBuilder`
- Added new `public` methods to `Request` class:
	- `getRequestBuilder`
	- `setRequestBuilder`
	- `releaseClient`